### PR TITLE
Integrate code block automation across chat entry points

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { createCommitMsgCommand } from './commands/commitMsg.js';
 import { createReviewCommand } from './commands/review.js';
 import { createMemoryCommand } from './commands/memory.js';
 import { createSetupCommand } from './commands/setup.js';
+import { handleCodeBlocks } from './utils/codeBlocks.js';
 
 async function showWelcomeScreen() {
   console.clear();
@@ -365,180 +366,6 @@ function showSlashHelp() {
   console.log(chalk.gray('💡 Tip: Use /provider to switch between Ollama, OpenAI, and Gemini'));
 }
 
-async function handleCodeBlocks(aiResponse: string) {
-  const { writeFileSync, existsSync, mkdirSync, readFileSync } = await import('fs');
-  const { join, dirname } = await import('path');
-
-  // Look for code blocks in the AI response
-  const codeBlockRegex = /```(\w+)?\n([\s\S]*?)```/g;
-  const matches = [...aiResponse.matchAll(codeBlockRegex)];
-
-  if (matches.length === 0) {
-    return; // No code blocks found
-  }
-
-  // Check if always allow is enabled
-  const alwaysAllow = process.env.DEVAI_ALWAYS_ALLOW === 'true';
-
-  console.log(chalk.bold.blue('\n📝 Creating/updating files from AI response...\n'));
-
-  for (const match of matches) {
-    const [, language, code] = match;
-    let cleanCode = code.trim();
-
-    // Try to extract filepath from comment at the top of the code block
-    let filename = '';
-    let filePath = '';
-    const filepathMatch = cleanCode.match(/^(?:\/\/|#|<!--)\s*filepath:\s*(.+?)(?:-->)?\n/i);
-
-    if (filepathMatch) {
-      // Extract filepath from comment
-      filename = filepathMatch[1].trim();
-      // Remove the filepath comment from the code
-      cleanCode = cleanCode.replace(/^(?:\/\/|#|<!--)\s*filepath:\s*.+?(?:-->)?\n/i, '').trim();
-
-      // Check if it's an absolute path
-      const { isAbsolute } = await import('path');
-      if (isAbsolute(filename)) {
-        filePath = filename;
-      } else {
-        filePath = join(process.cwd(), filename);
-      }
-    } else {
-      // Fallback: Determine file extension and name based on language
-      if (language === 'html') {
-        filename = 'index.html';
-      } else if (language === 'javascript' || language === 'js') {
-        filename = 'app.js';
-      } else if (language === 'css') {
-        filename = 'style.css';
-      } else if (language === 'python' || language === 'py') {
-        filename = 'main.py';
-      } else if (language === 'typescript' || language === 'ts') {
-        filename = 'index.ts';
-      } else if (language === 'json') {
-        filename = 'config.json';
-      } else {
-        // Default to .txt for unknown languages
-        filename = `code_${Date.now()}.txt`;
-      }
-      filePath = join(process.cwd(), filename);
-    }
-    
-    // Check if file already exists
-    const fileExists = existsSync(filePath);
-    let existingContent = '';
-    if (fileExists) {
-      try {
-        existingContent = readFileSync(filePath, 'utf-8');
-      } catch (error) {
-        existingContent = '';
-      }
-    }
-    
-    // Get display name (basename for absolute paths)
-    const { basename } = await import('path');
-    const displayName = basename(filePath);
-
-    // Show file analysis and diff
-    if (fileExists && existingContent !== cleanCode) {
-      console.log(chalk.yellow(`📄 Updating existing file: ${filePath}`));
-      showColoredDiff(existingContent, cleanCode);
-    } else if (!fileExists) {
-      console.log(chalk.green(`📄 Creating new file: ${filePath}`));
-      showFilePreview(cleanCode);
-    } else {
-      console.log(chalk.gray(`📄 File ${filePath} unchanged`));
-      continue;
-    }
-
-    // Quick confirmation for non-always-allow mode
-    let action = 'apply';
-    if (!alwaysAllow) {
-      const { confirm } = await inquirer.prompt([
-        {
-          type: 'confirm',
-          name: 'confirm',
-          message: `Apply changes to ${filePath}?`,
-          default: true
-        }
-      ]);
-
-      if (!confirm) {
-        console.log(chalk.gray(`Skipped ${filePath}`));
-        continue;
-      }
-    }
-
-    // Apply changes
-    try {
-      // Ensure directory exists
-      const dir = dirname(filePath);
-      if (!existsSync(dir)) {
-        mkdirSync(dir, { recursive: true });
-      }
-
-      writeFileSync(filePath, cleanCode, 'utf-8');
-      console.log(chalk.green(`✅ Created/updated: ${filePath}`));
-    } catch (error) {
-      console.log(chalk.red(`❌ Failed to create ${filePath}:`), error);
-    }
-  }
-  
-  console.log(chalk.gray('\n💡 Files are ready to use!'));
-}
-
-function showColoredDiff(oldContent: string, newContent: string) {
-  const oldLines = oldContent.split('\n');
-  const newLines = newContent.split('\n');
-  
-  console.log(chalk.gray('┌─ Changes:'));
-  
-  // Show first few lines of changes
-  let changeCount = 0;
-  const maxChanges = 8;
-  
-  for (let i = 0; i < Math.max(oldLines.length, newLines.length) && changeCount < maxChanges; i++) {
-    const oldLine = oldLines[i] || '';
-    const newLine = newLines[i] || '';
-    
-    if (oldLine !== newLine) {
-      changeCount++;
-      if (oldLine) {
-        console.log(chalk.red(`- ${oldLine}`));
-      }
-      if (newLine) {
-        console.log(chalk.green(`+ ${newLine}`));
-      }
-    } else if (changeCount > 0 && changeCount < 3) {
-      // Show context lines
-      console.log(chalk.gray(`  ${oldLine}`));
-    }
-  }
-  
-  if (changeCount >= maxChanges) {
-    console.log(chalk.gray('  ... (more changes)'));
-  }
-  
-  console.log(chalk.gray('└─'));
-}
-
-function showFilePreview(content: string) {
-  const lines = content.split('\n');
-  const previewLines = lines.slice(0, 5);
-  
-  console.log(chalk.gray('┌─ Preview:'));
-  previewLines.forEach(line => {
-    console.log(chalk.gray(`│ ${line}`));
-  });
-  
-  if (lines.length > 5) {
-    console.log(chalk.gray(`│ ... (${lines.length - 5} more lines)`));
-  }
-  
-  console.log(chalk.gray('└─'));
-}
-
 async function collectProjectContext() {
   const { readFileSync, existsSync, readdirSync, statSync } = await import('fs');
   const { join, extname } = await import('path');
@@ -871,7 +698,8 @@ export function createCLI(): Command {
 
         // Process user message with agent workflow
         try {
-          await agent.processMessage(userInput);
+          const aiResponse = await agent.processMessage(userInput);
+          await handleCodeBlocks(aiResponse);
         } catch (error) {
           console.log(chalk.red('\n❌ Error:'), error instanceof Error ? error.message : String(error));
         }

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import { createInterface } from 'readline';
 import { loadConfig } from '../config.js';
 import type { ChatMessage } from '../providers/base.js';
+import { handleCodeBlocks } from '../utils/codeBlocks.js';
 
 export function createChatCommand(): Command {
   const command = new Command('chat');
@@ -52,10 +53,13 @@ export function createChatCommand(): Command {
             process.stdout.write(chunk);
             assistantResponse += chunk;
           }
-          
+
+          console.log('');
+          await handleCodeBlocks(assistantResponse);
+
           // Add assistant response to history
           messages.push({ role: 'assistant', content: assistantResponse });
-          console.log('\n');
+          console.log('');
         }
         
         rl.close();

--- a/src/utils/codeBlocks.ts
+++ b/src/utils/codeBlocks.ts
@@ -1,0 +1,185 @@
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+
+interface HandleCodeBlocksOptions {
+  disableAutomationFlagEnv?: string;
+}
+
+const DEFAULT_DISABLE_FLAG = 'DEVAI_DISABLE_CODEBLOCK_AUTOMATION';
+
+export async function handleCodeBlocks(aiResponse: string, options: HandleCodeBlocksOptions = {}): Promise<void> {
+  if (!aiResponse?.trim()) {
+    return;
+  }
+
+  const disableFlag = options.disableAutomationFlagEnv ?? DEFAULT_DISABLE_FLAG;
+  if (process.env[disableFlag] === 'true') {
+    console.log(chalk.gray(`\n⚙️  Code block automation disabled via ${disableFlag}.`));
+    return;
+  }
+
+  // Look for code blocks in the AI response
+  const codeBlockRegex = /```(\w+)?\n([\s\S]*?)```/g;
+  const matches = [...aiResponse.matchAll(codeBlockRegex)];
+
+  if (matches.length === 0) {
+    return; // No code blocks found
+  }
+
+  // Check if always allow is enabled
+  const alwaysAllow = process.env.DEVAI_ALWAYS_ALLOW === 'true';
+
+  console.log(chalk.bold.blue('\n📝 Creating/updating files from AI response...\n'));
+
+  const { writeFileSync, existsSync, mkdirSync, readFileSync } = await import('fs');
+  const { join, dirname, isAbsolute } = await import('path');
+
+  for (const match of matches) {
+    const [, language, code] = match;
+    let cleanCode = code.trim();
+
+    // Try to extract filepath from comment at the top of the code block
+    let filename = '';
+    let filePath = '';
+    const filepathMatch = cleanCode.match(/^(?:\/\/|#|<!--)\s*filepath:\s*(.+?)(?:-->)?\n/i);
+
+    if (filepathMatch) {
+      // Extract filepath from comment
+      filename = filepathMatch[1].trim();
+      // Remove the filepath comment from the code
+      cleanCode = cleanCode.replace(/^(?:\/\/|#|<!--)\s*filepath:\s*.+?(?:-->)?\n/i, '').trim();
+
+      if (isAbsolute(filename)) {
+        filePath = filename;
+      } else {
+        filePath = join(process.cwd(), filename);
+      }
+    } else {
+      // Fallback: Determine file extension and name based on language
+      if (language === 'html') {
+        filename = 'index.html';
+      } else if (language === 'javascript' || language === 'js') {
+        filename = 'app.js';
+      } else if (language === 'css') {
+        filename = 'style.css';
+      } else if (language === 'python' || language === 'py') {
+        filename = 'main.py';
+      } else if (language === 'typescript' || language === 'ts') {
+        filename = 'index.ts';
+      } else if (language === 'json') {
+        filename = 'config.json';
+      } else {
+        // Default to .txt for unknown languages
+        filename = `code_${Date.now()}.txt`;
+      }
+      filePath = join(process.cwd(), filename);
+    }
+
+    // Check if file already exists
+    const fileExists = existsSync(filePath);
+    let existingContent = '';
+    if (fileExists) {
+      try {
+        existingContent = readFileSync(filePath, 'utf-8');
+      } catch (error) {
+        existingContent = '';
+      }
+    }
+
+    // Show file analysis and diff
+    if (fileExists && existingContent !== cleanCode) {
+      console.log(chalk.yellow(`📄 Updating existing file: ${filePath}`));
+      showColoredDiff(existingContent, cleanCode);
+    } else if (!fileExists) {
+      console.log(chalk.green(`📄 Creating new file: ${filePath}`));
+      showFilePreview(cleanCode);
+    } else {
+      console.log(chalk.gray(`📄 File ${filePath} unchanged`));
+      continue;
+    }
+
+    // Quick confirmation for non-always-allow mode
+    if (!alwaysAllow) {
+      const { confirm } = await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'confirm',
+          message: `Apply changes to ${filePath}?`,
+          default: true
+        }
+      ]);
+
+      if (!confirm) {
+        console.log(chalk.gray(`Skipped ${filePath}`));
+        continue;
+      }
+    }
+
+    // Apply changes
+    try {
+      // Ensure directory exists
+      const dir = dirname(filePath);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+
+      writeFileSync(filePath, cleanCode, 'utf-8');
+      console.log(chalk.green(`✅ Created/updated: ${filePath}`));
+    } catch (error) {
+      console.log(chalk.red(`❌ Failed to create ${filePath}:`), error);
+    }
+  }
+
+  console.log(chalk.gray('\n💡 Files are ready to use!'));
+}
+
+function showColoredDiff(oldContent: string, newContent: string) {
+  const oldLines = oldContent.split('\n');
+  const newLines = newContent.split('\n');
+
+  console.log(chalk.gray('┌─ Changes:'));
+
+  // Show first few lines of changes
+  let changeCount = 0;
+  const maxChanges = 8;
+
+  for (let i = 0; i < Math.max(oldLines.length, newLines.length) && changeCount < maxChanges; i++) {
+    const oldLine = oldLines[i] || '';
+    const newLine = newLines[i] || '';
+
+    if (oldLine !== newLine) {
+      changeCount++;
+      if (oldLine) {
+        console.log(chalk.red(`- ${oldLine}`));
+      }
+      if (newLine) {
+        console.log(chalk.green(`+ ${newLine}`));
+      }
+    } else if (changeCount > 0 && changeCount < 3) {
+      // Show context lines
+      console.log(chalk.gray(`  ${oldLine}`));
+    }
+  }
+
+  if (changeCount >= maxChanges) {
+    console.log(chalk.gray('  ... (more changes)'));
+  }
+
+  console.log(chalk.gray('└─'));
+}
+
+function showFilePreview(content: string) {
+  const lines = content.split('\n');
+  const previewLines = lines.slice(0, 5);
+
+  console.log(chalk.gray('┌─ Preview:'));
+  previewLines.forEach(line => {
+    console.log(chalk.gray(`│ ${line}`));
+  });
+
+  if (lines.length > 5) {
+    console.log(chalk.gray(`│ ... (${lines.length - 5} more lines)`));
+  }
+
+  console.log(chalk.gray('└─'));
+}


### PR DESCRIPTION
## Summary
- extract the code-block application flow into a shared utility with an opt-out flag
- invoke the handler from the default CLI chat loop so captured responses trigger file confirmations
- run the same automation after streaming chat responses for consistent behaviour across commands

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2c82027648326a4958b5e97aa7f63